### PR TITLE
fix(cd): pat env in goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,3 +40,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          PAT_HOMEBREW_TAP_REPO: ${{ secrets.PAT_HOMEBREW_TAP_REPO }}


### PR DESCRIPTION
## WHAT
- Set `PAT_HOMEBREW_TAP_REPO` as an environment variable on goreleaser workflow.

## WHY
- v0.0.2 release failed. https://github.com/kazuki-iwanaga/pr2otel/actions/runs/10811703747/job/29991674503

## CHECK LIST
- [ ]